### PR TITLE
Added `min` to the cdn link.

### DIFF
--- a/src/content/getting-started-webfont.md
+++ b/src/content/getting-started-webfont.md
@@ -14,7 +14,7 @@ bower install mdi
 ```
 
 ```
-https://cdn.materialdesignicons.com/{{version}}/css/materialdesignicons.css
+https://cdn.materialdesignicons.com/{{version}}/css/materialdesignicons.min.css
 ```
 
 ## Basic Example


### PR DESCRIPTION
In this very small PR, I've changed the cdn link to request the minified CSS file.
Instead of requesting `https://cdn.materialdesignicons.com/2.7.94/css/materialdesignicons.css`, it will now request `https://cdn.materialdesignicons.com/2.7.94/css/materialdesignicons.min.css`.