### PR TITLE
Add mdi-material-ui as a simpler way to use MDI with Material-UI.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -135,6 +135,13 @@ const appRoutes: Routes = [
     }
   },
   {
+    path: 'getting-started/react-material-ui',
+    component: ViewerPageComponent,
+    data: {
+      file: 'content/getting-started-react-material-ui.md'
+    }
+  },
+  {
     path: 'getting-started/rollupjs',
     component: ViewerPageComponent,
     data: {

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -82,6 +82,11 @@
                 React
                 <small>Component</small>
             </a>
+            <a class="item" routerLink="/getting-started/react-material-ui" routerLinkActive="active">
+                <mdi-icon [name]="'material-ui'"></mdi-icon>
+                Material-UI + React
+                <small>Component</small>
+            </a>
             <a class="item" routerLink="/getting-started/rollupjs" routerLinkActive="active">
                 <mdi-icon [name]="'rollupjs'"></mdi-icon>
                 rollup.js

--- a/src/app/shared/icon/icon.component.ts
+++ b/src/app/shared/icon/icon.component.ts
@@ -39,6 +39,7 @@ import {
     mdiCheckboxMarkedOutline,
     mdiArrowUpThick,
     mdiFormatListChecks,
+    mdiMaterialUi,
 } from '@mdi/js'
 
 @Component({
@@ -89,6 +90,7 @@ export class IconComponent  {
         new Icon('information-outline', mdiInformationOutline),
         new Icon('lightbulb-on', mdiLightbulbOn),
         new Icon('magnify', mdiMagnify),
+        new Icon('material-ui', mdiMaterialUi),
         new Icon('menu-down', mdiMenuDown),
         new Icon('menu-up', mdiMenuUp),
         new Icon('news', mdiNewspaper),

--- a/src/content/getting-started-react-material-ui.md
+++ b/src/content/getting-started-react-material-ui.md
@@ -1,4 +1,4 @@
-# React - Getting Started
+# Material-UI - Getting Started
 
 Material Design Icons can be used in React with [Material-UI](https://material-ui.com)'s `SvgIcon` component.
 

--- a/src/content/getting-started-react-material-ui.md
+++ b/src/content/getting-started-react-material-ui.md
@@ -1,0 +1,34 @@
+# React - Getting Started
+
+Material Design Icons can be used in React with [Material-UI](https://material-ui.com)'s `SvgIcon` component.
+
+```
+npm install mdi-material-ui
+```
+
+<a href="https://github.com/TeamWertarbyte/mdi-material-ui" class="btn btn-outline-secondary">icon:github-circle mdi-material-ui on GitHub</a>
+
+## Usage
+
+The icon names are converted to `PascalCase`, e.g. the `material-ui` icon is exported as `MaterialUi`.
+
+```jsx
+import React, { Component } from 'react'
+import { MaterialUi } from 'mdi-material-ui'
+
+class App extends Component {
+  render() {
+    return (
+      <MaterialUi />
+    )
+  }
+} 
+```
+
+## Props
+
+Every icon is a `SvgIcon` and supports the same props as Material-UI's [SvgIcon](https://material-ui.com/api/svg-icon/).
+
+## Styling
+
+Applying a `className` attribute is usually the easiest solution. Examples are available in the [Material-UI docs](https://material-ui.com/style/icons/).

--- a/src/content/sidebar.md
+++ b/src/content/sidebar.md
@@ -8,6 +8,7 @@
 - /getting-started/php
 - /getting-started/polymer
 - /getting-started/react
+- /getting-started/react-material-ui
 - /getting-started/rollupjs
 - /getting-started/ruby-on-rails
 - /getting-started/svg
@@ -26,6 +27,7 @@
   - language-php PHP _Twig_ /getting-started/php
   - polymer Polymer _v0.5 / v1.0 Supported_ /getting-started/polymer
   - react React /getting-started/react
+  - material-ui Material-UI + React /getting-started/react-material-ui
   - rollupjs rollup.js /getting-started/rollupjs
   - ruby-on-rails Ruby on Rails /getting-started/ruby-on-rails
   - svg SVG /getting-started/svg


### PR DESCRIPTION
This adds [mdi-material-ui](https://github.com/TeamWertarbyte/mdi-material-ui) as a new way to get started with MDI when using React.

While the default React package is already great, [Material-UI](https://github.com/mui-org/material-ui) is pretty popular and using that package makes using the Material Design Icons a bit easier if you're already using MUI anyway.

Edit: I see that this might not be the official way of using MDI and I understand if this doesn't get merged. :+1: 