### PR TITLE
Fix Angular Material docs

### DIFF
--- a/src/content/getting-started-angular.md
+++ b/src/content/getting-started-angular.md
@@ -129,6 +129,10 @@ a.mat-menu-item > mat-icon {
   height: 24px;
   width: 24px;
 }
+.mat-step-icon-content .mat-icon svg {
+	height: 100%;
+	width: 100%;
+}
 ```
 
 [Demo](https://stackblitz.com/edit/mdi-material-example)


### PR DESCRIPTION
Angular Material menu icon's fix breaks the icons from the stepper component by setting a 24px fixed size on every icon. This fix overrides that rule when a icon is part of a mat-stepper component.

Before: 
![Screenshot from 2019-09-20 12-31-27](https://user-images.githubusercontent.com/13015727/65320687-b3d86900-dba2-11e9-8118-8a8bee364158.png)

After:
![Screenshot from 2019-09-20 12-31-43](https://user-images.githubusercontent.com/13015727/65320698-ba66e080-dba2-11e9-877c-cec0d4834f6b.png)

