### PR TITLE
Release page: FAQ tweaks

### DIFF
--- a/src/app/admin/iconsPage/iconsPage.component.html
+++ b/src/app/admin/iconsPage/iconsPage.component.html
@@ -326,8 +326,8 @@
                       </tr>
                       <tr>
                         <td><code># Header 1</code></td>
-                        <td><code># Header 2</code></td>
-                        <td><code># Header 3</code></td>
+                        <td><code>## Header 2</code></td>
+                        <td><code>### Header 3</code></td>
                       </tr>
                       <tr>
                         <td><code>- Item List</code></td>

--- a/src/app/admin/releasePage/releasePage.component.html
+++ b/src/app/admin/releasePage/releasePage.component.html
@@ -196,24 +196,24 @@
           <h2>FAQ</h2>
           <ul>
             <li>
-              <strong>Q. Icon is Missing</strong>
-              <p>A. Make sure it is published and not in a draft state.</p>
+              <strong>Icon is Missing</strong>
+              <p>Make sure it is published and not in a draft state.</p>
             </li>
             <li>
-              <strong>Q. What is a codepoint?</strong>
-              <p>A. A codepoints is a index (hex encoded) in a font. These must be unique within a single font and should not change between releases.</p>
+              <strong>What is a codepoint?</strong>
+              <p>A codepoint is an index (hex encoded) in a font. Codepoints must be unique within a single font and should not change between releases.</p>
             </li>
             <li>
-              <strong>Q. How do I know what codepoint to use?</strong>
-              <p>A. Assuming you want the next in the series simply click in a blank input.</p>
+              <strong>How do I know what codepoint to use?</strong>
+              <p>Assuming you want the next in the series simply click in a blank input.</p>
             </li>
             <li>
-              <strong>Q. Can I assign codepoints out of order?</strong>
-              <p>A. No, it will literally break everything.</p>
+              <strong>Can I assign codepoints out of order?</strong>
+              <p>No, it will literally break everything.</p>
             </li>
             <li>
-              <strong>Q. It won't let me generate published versions?</strong>
-              <p>A. Unfortantly due to renames there is no way to generate legacy builds.</p>
+              <strong>It won't let me generate published versions?</strong>
+              <p>Unfortantly due to renames there is no way to generate legacy builds.</p>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
- Remove `Q.` and `A.` prefixes
- Fix sentence