### PR TITLE
Fix h1 encoding issue (document title and GitHub issue link)

### DIFF
--- a/src/site/pageGithub/pageGithub.ts
+++ b/src/site/pageGithub/pageGithub.ts
@@ -69,9 +69,11 @@ export default class SitePageGithub extends HTMLElement {
 
   connectedCallback() {
     this.$markdown.file = GITHUB_FILE;
-    this.$edit.href = `https://github.com/Templarian/MaterialDesign-Site/tree/master/src/${GITHUB_FILE}`;
+    this.$edit.href = `https://github.com/Templarian/MaterialDesign-Site/blob/master/src${GITHUB_FILE}`;
     const h1 = 'GitHub Icon Preview Generator Instructions';
-    this.$suggest.href = `https://github.com/Templarian/MaterialDesign-Site/issues/new?title=Suggested%20Change%20to%20%22${h1}%22&body=%3C%21--%20Describe%20how%20you%20would%20improve%20the%20documentation%20here%20--%3E`;
+    const title = encodeURIComponent(`Suggested Change to "${h1}"`);
+    const body = encodeURIComponent(`<!-- Describe how you would improve the documentation here -->`);
+    this.$suggest.href = `https://github.com/Templarian/MaterialDesign-Site/issues/new?title=${title}&body=${body}`;
     this.$wipYes.addEventListener('click', () => {
       this.wip = true;
     });

--- a/src/site/pageView/pageView.ts
+++ b/src/site/pageView/pageView.ts
@@ -56,7 +56,9 @@ export default class SitePageView extends HTMLElement {
         this.$header.innerHTML = h1;
         const decodedTitle = this.$header.textContent ?? window.location.pathname;
         document.title = decodedTitle;
-        this.$suggest.href = `https://github.com/Templarian/MaterialDesign-Site/issues/new?title=Suggested%20Change%20to%20%22${encodeURIComponent(decodedTitle)}%22&body=%3C%21--%20Describe%20how%20you%20would%20improve%20the%20documentation%20here%20--%3E`;
+        const title = encodeURIComponent(`Suggested Change to "${decodedTitle}"`);
+        const body = encodeURIComponent(`<!-- Describe how you would improve the documentation here -->`);
+        this.$suggest.href = `https://github.com/Templarian/MaterialDesign-Site/issues/new?title=${title}&body=${body}`;
         return '';
       }
     }, {
@@ -127,7 +129,7 @@ export default class SitePageView extends HTMLElement {
       });
       var file = match ? match.file : '/content/404.md';
       this.$markdown.file = file;
-      this.$edit.href = `https://github.com/Templarian/MaterialDesign-Site/tree/master/src/${file}`;
+      this.$edit.href = `https://github.com/Templarian/MaterialDesign-Site/blob/master/src${file}`;
     }
     if (changes.icons) {
       this.initIcons = true;

--- a/src/site/pageView/pageView.ts
+++ b/src/site/pageView/pageView.ts
@@ -53,9 +53,10 @@ export default class SitePageView extends HTMLElement {
       find: new RegExp('<h1>(.*)</h1>'),
       replace: (m, h1) => {
         // Prevent double setting title
-        document.title = h1;
         this.$header.innerHTML = h1;
-        this.$suggest.href = `https://github.com/Templarian/MaterialDesign-Site/issues/new?title=Suggested%20Change%20to%20%22${h1}%22&body=%3C%21--%20Describe%20how%20you%20would%20improve%20the%20documentation%20here%20--%3E`;
+        const decodedTitle = this.$header.textContent ?? window.location.pathname;
+        document.title = decodedTitle;
+        this.$suggest.href = `https://github.com/Templarian/MaterialDesign-Site/issues/new?title=Suggested%20Change%20to%20%22${encodeURIComponent(decodedTitle)}%22&body=%3C%21--%20Describe%20how%20you%20would%20improve%20the%20documentation%20here%20--%3E`;
         return '';
       }
     }, {


### PR DESCRIPTION
Fixes HTML entity issue in title:

![image](https://user-images.githubusercontent.com/7819991/88980654-7cf3d900-d2c4-11ea-81e3-bef4b60b3075.png)

Fixes "Suggest a change" link so that the entire title is preserved:

![image](https://user-images.githubusercontent.com/7819991/88980762-ad3b7780-d2c4-11ea-8812-26a6c152fa66.png)

http://dev.materialdesignicons.com/contribute/site