### PR TITLE
rename "scooter-human" -> "human-scooter"

### DIFF
--- a/src/content/changelog.md
+++ b/src/content/changelog.md
@@ -4,7 +4,7 @@
 
 - 100 New Icons
 - Renamed
-  - `scooter` to `scooter-human`
+  - `scooter` to `human-scooter`
     - `scooter` in next release
 - Updated
   - `account-tie`

--- a/src/content/upgrade.md
+++ b/src/content/upgrade.md
@@ -5,7 +5,7 @@ Follow the guide starting with your version to the version you wish to upgrade t
 ## 5.4.45 to 5.5.55
 
 - Renamed
-  - `scooter` to `scooter-human`
+  - `scooter` to `human-scooter`
     - `scooter` in next release
 
 ## 5.3.45 to 5.4.55


### PR DESCRIPTION
Renamed "scooter-human" -> "human-scooter" in the 5.4.45 to 5.5.55 upgrade guide
Ref: https://materialdesignicons.com/icon/human-scooter